### PR TITLE
Update 009-Overzicht_Klassen.md

### DIFF
--- a/009-Overzicht_Klassen.md
+++ b/009-Overzicht_Klassen.md
@@ -1,8 +1,8 @@
 ## Overzicht Klassen {#1086A1F8}
-Het volgende diagram geeft een overzicht van de basis functionaliteit van [[DCAT-3.0]] en dient als startblok voor het begrijpen van de constructie. LET OP, er zijn dus meer klassen, eigenschappen en relaties dan weergegeven zoals te zien in Klassen.
+Het volgende diagram geeft een overzicht van de basisfunctionaliteit van [[DCAT-3.0]] en dient als startblok voor het begrijpen van de constructie. LET OP, er zijn dus meer klassen, eigenschappen en relaties dan weergegeven zoals te zien in de sectie Klassen hieronder.
 <figure><img src='media/overzicht klassen.png' alt='Afbeelding met tekst' style='width: 100%;'></img>
   
-<figcaption> Overzicht klassen</figcaption></figure>
+<figcaption>Overzicht klassen</figcaption></figure>
 
 
 


### PR DESCRIPTION
Verwarring "zoals te zien in Klassen" proberen op te lossen; "basisfunctionaliteit" is 1 woord; extra spatie in figcaption verwijderd.